### PR TITLE
fix(vulnerabilities): claim! を完全静的化し副作用チャレンジを検出可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ module Vulnerabilities
         hint        "リダイレクト先のパラメータを確認してみましょう"
         cwe         "CWE-601"
         reference   "https://guides.rubyonrails.org/security.html#redirection"
+        slot        "TasksController#create"
       end
 
       def apply!
@@ -237,6 +238,7 @@ end
 | `category` | ○ | カテゴリ（`:xss`, `:injection`, `:csrf` 等） |
 | `difficulty` | ○ | 難易度（`:easy`, `:medium`, `:hard`） |
 | `description` | ○ | 概要説明 |
+| `slot` | ○ | 占有するスロット識別子。`prepend_to` で差し込むメソッドは `"ClassName#method_name"`、`inject_view` で書き換えるパスは `"view:path/to/partial.html.erb"` の形式で指定する。複数ある場合は `slot "A", "B"` または複数回呼び出す |
 | `hint` | | ヒント（複数回呼べる） |
 | `cwe` | | CWE 番号 |
 | `reference` | | 参考 URL |

--- a/lib/vulnerabilities/base.rb
+++ b/lib/vulnerabilities/base.rb
@@ -23,22 +23,11 @@ module Vulnerabilities
       raise NotImplementedError, "#{self.class}#apply! を実装してください"
     end
 
-    # apply! を dry-run して占有する slot キーの一覧を返す。
-    # prepend_to / inject_view をシングルトンメソッドで一時差し替えし、
-    # 実際の inject は行わずキーだけ記録する。
+    # metadata の slot 宣言に基づき占有する slot キーの一覧を返す。
+    # apply! は呼ばないため副作用ゼロ。
+    # 全チャレンジは metadata ブロックで slot を宣言する必要がある。
     def claim!
-      slots = []
-      define_singleton_method(:prepend_to) do |klass, mod|
-        mod.instance_methods(false).each { |m| slots << "#{klass.name}##{m}" }
-      end
-      define_singleton_method(:inject_view) do |path, _content|
-        slots << "view:#{path}"
-      end
-      apply!
-      slots
-    ensure
-      singleton_class.remove_method(:prepend_to) rescue nil
-      singleton_class.remove_method(:inject_view) rescue nil
+      self.class.meta&.dig(:slots) || []
     end
 
     private
@@ -80,6 +69,7 @@ module Vulnerabilities
       def hint(val);        (@hash[:hints] ||= []) << val; end
       def cwe(val);         @hash[:cwe] = val; end
       def reference(val);   @hash[:reference] = val; end
+      def slot(*vals);      (@hash[:slots] ||= []).concat(vals); end
     end
   end
 end

--- a/lib/vulnerabilities/challenges/command_injection.rb
+++ b/lib/vulnerabilities/challenges/command_injection.rb
@@ -15,6 +15,7 @@ module Vulnerabilities
         hint        "name=$(whoami) を試してみましょう — ファイル名にコマンド実行結果が含まれます"
         cwe         "CWE-78"
         reference   "https://guides.rubyonrails.org/security.html#command-line-injection"
+        slot        "TasksController#export"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/csp_disable.rb
+++ b/lib/vulnerabilities/challenges/csp_disable.rb
@@ -14,6 +14,7 @@ module Vulnerabilities
         hint        "CSP がない場合、XSSの影響が大きくなります"
         cwe         "CWE-693"
         reference   "https://guides.rubyonrails.org/security.html#content-security-policy"
+        slot        "ApplicationController.content_security_policy"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/csrf_skip.rb
+++ b/lib/vulnerabilities/challenges/csrf_skip.rb
@@ -14,6 +14,7 @@ module Vulnerabilities
         hint        "curl で直接 POST してタスクが作成できるか試してみましょう"
         cwe         "CWE-352"
         reference   "https://guides.rubyonrails.org/security.html#cross-site-request-forgery-csrf"
+        slot        "TasksController.forgery_protection"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/css_injection.rb
+++ b/lib/vulnerabilities/challenges/css_injection.rb
@@ -14,6 +14,7 @@ module Vulnerabilities
         hint        "カラーに 'red; background:blue' を入れてページの見た目が変わるか確認しましょう"
         cwe         "CWE-79"
         reference   "https://guides.rubyonrails.org/security.html#css-injection"
+        slot        "view:tasks/_task_color.html.erb"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/header_removal.rb
+++ b/lib/vulnerabilities/challenges/header_removal.rb
@@ -14,6 +14,7 @@ module Vulnerabilities
         hint        "X-Content-Type-Options: nosniff が欠落しています"
         cwe         "CWE-693"
         reference   "https://guides.rubyonrails.org/security.html#default-headers"
+        slot        "ApplicationController.security_headers_after_action"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/idor.rb
+++ b/lib/vulnerabilities/challenges/idor.rb
@@ -14,6 +14,7 @@ module Vulnerabilities
         hint        "set_task が current_user.tasks.find ではなく Task.find になっています"
         cwe         "CWE-639"
         reference   "https://guides.rubyonrails.org/security.html#unauthorized-viewing"
+        slot        "TasksController#set_task"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/log_leakage.rb
+++ b/lib/vulnerabilities/challenges/log_leakage.rb
@@ -14,6 +14,7 @@ module Vulnerabilities
         hint        "config.filter_parameters が空になっています"
         cwe         "CWE-532"
         reference   "https://guides.rubyonrails.org/security.html#logging"
+        slot        "Rails.filter_parameters"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/mass_assignment.rb
+++ b/lib/vulnerabilities/challenges/mass_assignment.rb
@@ -14,6 +14,7 @@ module Vulnerabilities
         hint        "permit! は全パラメータを許可します"
         cwe         "CWE-915"
         reference   "https://guides.rubyonrails.org/security.html#mass-assignment"
+        slot        "TasksController#task_params"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/open_redirect.rb
+++ b/lib/vulnerabilities/challenges/open_redirect.rb
@@ -15,6 +15,7 @@ module Vulnerabilities
         hint        "return_to パラメータに外部URLを指定してみましょう"
         cwe         "CWE-601"
         reference   "https://guides.rubyonrails.org/security.html#redirection"
+        slot        "ApplicationController#safe_redirect_to"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/regex_bypass.rb
+++ b/lib/vulnerabilities/challenges/regex_bypass.rb
@@ -15,6 +15,7 @@ module Vulnerabilities
         hint        "URLフィールドに\\njavascript:alert(1) のような値を入れてみましょう"
         cwe         "CWE-185"
         reference   "https://guides.rubyonrails.org/security.html#regular-expressions"
+        slot        "Task.url_format_validator"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/session_fixation.rb
+++ b/lib/vulnerabilities/challenges/session_fixation.rb
@@ -14,6 +14,7 @@ module Vulnerabilities
         hint        "reset_session がないとサーバー側のセッションレコードにuser_idが書き込まれ、攻撃者のIDが認証済みになります"
         cwe         "CWE-384"
         reference   "https://guides.rubyonrails.org/security.html#session-fixation"
+        slot        "SessionsController#create"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/sql_injection.rb
+++ b/lib/vulnerabilities/challenges/sql_injection.rb
@@ -14,6 +14,7 @@ module Vulnerabilities
         hint        "' OR 1=1-- を検索ボックスに入れてみましょう"
         cwe         "CWE-89"
         reference   "https://guides.rubyonrails.org/security.html#sql-injection"
+        slot        "TasksController#apply_task_search"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/sql_injection_active_record.rb
+++ b/lib/vulnerabilities/challenges/sql_injection_active_record.rb
@@ -16,6 +16,7 @@ module Vulnerabilities
         hint        "with() で作った CTE スコープはバイパスできます"
         cwe         "CWE-89"
         reference   "https://rails-sqli.org/#from"
+        slot        "TasksController#set_view_type", "TasksController#set_task_scope"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/sql_injection_order.rb
+++ b/lib/vulnerabilities/challenges/sql_injection_order.rb
@@ -16,6 +16,7 @@ module Vulnerabilities
         hint        "sort=(CASE WHEN 1=1 THEN title ELSE created_at END) でブラインド注入が可能です"
         cwe         "CWE-89"
         reference   "https://rails-sqli.org/#order"
+        slot        "TasksController#apply_task_search"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/unsafe_file_upload.rb
+++ b/lib/vulnerabilities/challenges/unsafe_file_upload.rb
@@ -14,6 +14,7 @@ module Vulnerabilities
         hint        "MIMEタイプのホワイトリスト検証が無効になっています"
         cwe         "CWE-434"
         reference   "https://guides.rubyonrails.org/security.html#file-uploads"
+        slot        "Task.acceptable_attachment_validation"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/xss_raw.rb
+++ b/lib/vulnerabilities/challenges/xss_raw.rb
@@ -14,6 +14,7 @@ module Vulnerabilities
         hint        "<script>alert('XSS')</script> をタイトルに入れてみましょう"
         cwe         "CWE-79"
         reference   "https://guides.rubyonrails.org/security.html#cross-site-scripting-xss"
+        slot        "view:tasks/_task_title.html.erb"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/xss_reflected.rb
+++ b/lib/vulnerabilities/challenges/xss_reflected.rb
@@ -14,6 +14,7 @@ module Vulnerabilities
         hint        "?q=<script>alert(1)</script> を URL に入れてみましょう"
         cwe         "CWE-79"
         reference   "https://guides.rubyonrails.org/security.html#cross-site-scripting-xss"
+        slot        "view:tasks/_search_label.html.erb"
       end
 
       def apply!

--- a/lib/vulnerabilities/challenges/xss_stored_img.rb
+++ b/lib/vulnerabilities/challenges/xss_stored_img.rb
@@ -12,6 +12,7 @@ module Vulnerabilities
         hint        "説明欄に <img src=x onerror=alert(1)> を入力して画像を添付してみましょう"
         cwe         "CWE-79"
         reference   "https://guides.rubyonrails.org/security.html#cross-site-scripting-xss"
+        slot        "view:tasks/_task_attachment.html.erb"
       end
 
       def apply!

--- a/test/integration/vulnerabilities/claim_no_side_effects_test.rb
+++ b/test/integration/vulnerabilities/claim_no_side_effects_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# claim! が副作用を伴わないチャレンジに対して副作用ゼロで slot を返すことを検証する。
+# これらのチャレンジは metadata に slot 宣言を持つため、claim! は apply! を呼ばない。
+class ClaimNoSideEffectsTest < ActiveSupport::TestCase
+  STATIC_SLOT_CHALLENGES = [
+    Vulnerabilities::Challenges::CsrfSkip,
+    Vulnerabilities::Challenges::CspDisable,
+    Vulnerabilities::Challenges::RegexBypass,
+    Vulnerabilities::Challenges::UnsafeFileUpload,
+    Vulnerabilities::Challenges::LogLeakage,
+    Vulnerabilities::Challenges::HeaderRemoval,
+  ].freeze
+
+  STATIC_SLOT_CHALLENGES.each do |klass|
+    test "#{klass.slug}: claim! returns non-empty slot list" do
+      slots = klass.new.claim!
+      assert_kind_of Array, slots
+      assert slots.any?, "#{klass.slug}#claim! は少なくとも1つの slot を返す必要があります"
+    end
+
+    test "#{klass.slug}: claim! does not invoke apply!" do
+      challenge = klass.new
+      apply_called = false
+      challenge.define_singleton_method(:apply!) { apply_called = true }
+      challenge.claim!
+      assert_not apply_called, "#{klass.slug}#claim! は apply! を呼んではいけません"
+    end
+  end
+
+  test "csrf_skip slot name matches declaration" do
+    assert_equal ["TasksController.forgery_protection"],
+                 Vulnerabilities::Challenges::CsrfSkip.new.claim!
+  end
+
+  test "csp_disable slot name matches declaration" do
+    assert_equal ["ApplicationController.content_security_policy"],
+                 Vulnerabilities::Challenges::CspDisable.new.claim!
+  end
+
+  test "regex_bypass slot name matches declaration" do
+    assert_equal ["Task.url_format_validator"],
+                 Vulnerabilities::Challenges::RegexBypass.new.claim!
+  end
+
+  test "unsafe_file_upload slot name matches declaration" do
+    assert_equal ["Task.acceptable_attachment_validation"],
+                 Vulnerabilities::Challenges::UnsafeFileUpload.new.claim!
+  end
+
+  test "log_leakage slot name matches declaration" do
+    assert_equal ["Rails.filter_parameters"],
+                 Vulnerabilities::Challenges::LogLeakage.new.claim!
+  end
+
+  test "header_removal slot name matches declaration" do
+    assert_equal ["ApplicationController.security_headers_after_action"],
+                 Vulnerabilities::Challenges::HeaderRemoval.new.claim!
+  end
+end

--- a/test/integration/vulnerabilities/conflict_resolution_test.rb
+++ b/test/integration/vulnerabilities/conflict_resolution_test.rb
@@ -17,6 +17,9 @@ class ConflictResolutionTest < ActiveSupport::TestCase
     # xss_raw と同じ slot を狙うダミーチャレンジを登録
     dummy = Class.new(Vulnerabilities::Base) do
       define_singleton_method(:slug) { "xss_raw_v2_test_only" }
+      metadata do
+        slot "view:tasks/_task_title.html.erb"
+      end
       def apply!
         inject_view "tasks/_task_title.html.erb", "<div>dummy</div>"
       end


### PR DESCRIPTION
## Summary

- `MetadataDSL` に `slot` メソッドを追加
- `claim!` を動的 dry-run から `meta[:slots]` を返す1行に簡略化し、動的検出機構を廃止
- 全18チャレンジに `slot` 宣言を追加（`conflict_resolution_test.rb` のダミーチャレンジも含む）
- README のメタデータ DSL 表とコード例に `slot` を追記

## Background

`claim!` は `prepend_to` / `inject_view` をスタブ差し替えする dry-run 方式だったが、この2つを使わない6チャレンジ（`csrf_skip`, `csp_disable`, `regex_bypass`, `unsafe_file_upload`, `log_leakage`, `header_removal`）では `apply!` が実際に実行され副作用が発生していた。またスタブ方式では `slot` 宣言と `prepend_to` を混在させるとサイレントに壊れるリスクもあった。

## Test plan

- [ ] `podman compose run --rm web bin/rails test test/integration/vulnerabilities/claim_no_side_effects_test.rb`
- [ ] `podman compose run --rm web bin/rails test test/integration/vulnerabilities/conflict_resolution_test.rb`

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)