### PR TITLE
fix(registry): view_path の重複蓄積と descendants 非伝播を修正

### DIFF
--- a/lib/vulnerabilities/base.rb
+++ b/lib/vulnerabilities/base.rb
@@ -43,7 +43,6 @@ module Vulnerabilities
       vuln_view_path = Rails.root.join("lib/vulnerabilities/views")
       FileUtils.mkdir_p(vuln_view_path.join(File.dirname(relative_path)))
       File.write(vuln_view_path.join(relative_path), content)
-      ActionController::Base.prepend_view_path(vuln_view_path.to_s)
     end
 
     # 動的にルートを追加する

--- a/lib/vulnerabilities/registry.rb
+++ b/lib/vulnerabilities/registry.rb
@@ -60,6 +60,15 @@ module Vulnerabilities
         $stdout.puts "[Vuln] Applying challenge: #{klass.slug}"
         klass.new.apply!
       end
+
+      vuln_view_path = Rails.root.join("lib/vulnerabilities/views").to_s
+      if Dir.exist?(vuln_view_path) && Dir.glob("#{vuln_view_path}/**/*.erb").any?
+        [ActionController::Base, *ActionController::Base.descendants].each do |ctrl|
+          next unless ctrl.respond_to?(:view_paths)
+          next if ctrl.view_paths.map(&:to_s).include?(vuln_view_path)
+          ctrl.prepend_view_path(vuln_view_path)
+        end
+      end
     end
 
     # --- 環境変数 or 設定ファイルから初期化 ---

--- a/test/integration/vulnerabilities/apply_all_view_paths_test.rb
+++ b/test/integration/vulnerabilities/apply_all_view_paths_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Issue #2: apply_all! を複数回呼んでも view_paths に重複が生じないことを検証
+# Issue #3: ActionController::Base の descendants にも view_path が伝播することを検証
+class ApplyAllViewPathsTest < ActiveSupport::TestCase
+  setup do
+    @registry = Vulnerabilities::Registry.instance
+    @original_active     = @registry.instance_variable_get(:@active).dup
+    @original_challenges = @registry.instance_variable_get(:@challenges).dup
+    @registry.instance_variable_set(:@active, Set.new)
+    @registry.instance_variable_set(:@conflict_log, [])
+
+    # view を inject するダミーチャレンジ
+    dummy = Class.new(Vulnerabilities::Base) do
+      define_singleton_method(:slug) { "view_path_test_dummy" }
+      metadata do
+        slot "view:tasks/_view_path_test.html.erb"
+      end
+      def apply!
+        inject_view "tasks/_view_path_test.html.erb", "<div>test</div>"
+      end
+    end
+    @registry.instance_variable_get(:@challenges)["view_path_test_dummy"] = dummy
+    @registry.enable("view_path_test_dummy")
+
+    @vuln_view_path = Rails.root.join("lib/vulnerabilities/views").to_s
+  end
+
+  teardown do
+    @registry.instance_variable_set(:@active, @original_active)
+    @registry.instance_variable_set(:@challenges, @original_challenges)
+    @registry.instance_variable_set(:@conflict_log, [])
+    FileUtils.rm_f(Dir[Rails.root.join("lib/vulnerabilities/views/tasks/_view_path_test.html.erb")])
+  end
+
+  # Issue #2: apply_all! を3回呼んでも vuln_view_path の出現回数が1のまま
+  test "apply_all! called multiple times does not duplicate view_paths" do
+    3.times { @registry.apply_all! }
+
+    count = ActionController::Base.view_paths.map(&:to_s).count(@vuln_view_path)
+    assert_equal 1, count, "view_paths に #{@vuln_view_path} が #{count} 回含まれている（期待: 1）"
+  end
+
+  # Issue #3: copy-on-write で分離したサブクラスにも view_path が伝播する
+  test "apply_all! propagates view_path to descendants that have been split by copy-on-write" do
+    # view_paths を明示的に設定することで vuln_view_path を持たない独立したコントローラを作る
+    isolated_ctrl = Class.new(ActionController::Base)
+    isolated_ctrl.view_paths = [Rails.root.join("app/views").to_s]
+
+    refute_includes isolated_ctrl.view_paths.map(&:to_s), @vuln_view_path,
+      "前提: isolated_ctrl は vuln_view_path を持っていないはず"
+
+    @registry.apply_all!
+
+    assert_includes isolated_ctrl.view_paths.map(&:to_s), @vuln_view_path,
+      "isolated_ctrl に vuln_view_path が伝播していない"
+  end
+end


### PR DESCRIPTION
## Summary

- `inject_view` から `prepend_view_path` を除去し、`apply_all!` 末尾で一括登録に変更
- `ActionController::Base.descendants` 全体に伝播させることで copy-on-write 分離後の非伝播を解消
- `respond_to?(:view_paths)` ガードを追加
- 両 issue を再現・検証するテストを追加

Closes #2, Closes #3

## Test plan

- [ ] `podman compose run --rm web bin/rails test test/integration/vulnerabilities/apply_all_view_paths_test.rb` で2テスト PASS
- [ ] `podman compose run --rm web bin/rails test test/integration/vulnerabilities/` で全87テスト PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)