### PR TITLE
fix: Ruby 3.4 compatibility (follow-up for #24)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
-ARG RUBY_VERSION=3.2.3
+ARG RUBY_VERSION=3.4.9
 
 # Development stage
 FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as development
@@ -10,11 +10,13 @@ WORKDIR /rails
 
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y \
-      build-essential git pkg-config libsqlite3-dev curl \
+      build-essential git pkg-config libsqlite3-dev curl libyaml-dev \
       chromium && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 ENV BUNDLE_PATH="/usr/local/bundle"
+
+RUN gem install bundler:2.6.9
 
 COPY Gemfile Gemfile.lock ./
 RUN bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "puma", ">= 5.0"
 gem "bcrypt", "~> 3.1.7"
 gem "activerecord-session_store"
 gem "redis", "~> 5.0"
+gem "csv"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -244,6 +245,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-session_store
   bcrypt (~> 3.1.7)
+  csv
   debug
   ferrum (~> 0.15)
   minitest (~> 5.16)
@@ -260,4 +262,4 @@ RUBY VERSION
    ruby 3.4.9p82
 
 BUNDLED WITH
-   2.4.19
+   2.6.9


### PR DESCRIPTION
## Summary

Follow-up to #24 (Ruby 3.2.3 → 3.4.9). Changes needed for Ruby 3.4 compatibility:

- `Dockerfile`: Update `RUBY_VERSION` to 3.4.9, add `libyaml-dev` (required by psych native extension), pin `bundler:2.6.9` (version bundled with Ruby 3.4.9)
- `Gemfile`: Add `csv` gem — removed from Ruby default gems since 3.4.0
- `Gemfile.lock`: Update `BUNDLED WITH` to 2.6.9

## Test plan

- [x] `docker compose build web` succeeds
- [x] `docker compose run --rm web bin/rails test` — 110 tests, 0 failures