### PR TITLE
chore(deps): update dependency puma to v8 (再修正 #27)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (7.2.0)
+    puma (8.0.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)


### PR DESCRIPTION
PR #27 をテストなしでマージしてしまったため revert し、正しい手順で再修正したものです。

- main の先端に rebase 済み
- フルテスト通過: 110 tests, 0 failures