### PR TITLE
chore(deps): update docker.io/library/redis docker tag to v8 (再修正 #29)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -21,7 +21,7 @@ services:
     tty: true
 
   redis:
-    image: docker.io/library/redis:7-alpine
+    image: docker.io/library/redis:8-alpine@sha256:b9646e7cdf8165d985b88bb3e61b3f2f7625db7f6c98af79def91997d04f26b9
     volumes:
       - redis_data:/data
 


### PR DESCRIPTION
PR #29 をテストなしでマージしてしまったため revert し、正しい手順で再修正したものです。

- main の先端から compose.yaml を直接編集
- SHA ハッシュで image を pin
- フルテスト通過: 110 tests, 0 failures