### PR TITLE
fix(vuln): make add_routes prepend block idempotent to prevent route collision on reload

### DIFF
--- a/lib/vulnerabilities/base.rb
+++ b/lib/vulnerabilities/base.rb
@@ -63,12 +63,22 @@ module Vulnerabilities
       routes = Rails.application.routes
       return unless routes
 
-      routes.prepend(&block)  # clear! のたびに再評価されるよう登録
+      # @prepend ブロックは clear! のたびに再実行される。
+      # 同じブロックが複数回登録された場合（開発モードでの Registry 再生成など）も含め、
+      # 重複定義エラーを無視するラッパーで包む。
+      idempotent = proc {
+        begin
+          instance_exec(&block)
+        rescue ArgumentError => e
+          raise e unless e.message.include?("Invalid route name, already in use")
+        end
+      }
+
+      routes.prepend(&idempotent)
       routes.disable_clear_and_finalize = true
       begin
-        routes.draw(&block)
+        routes.draw(&idempotent)
       rescue ArgumentError => e
-        # ルート名重複は既に定義済みとして無視
         raise e unless e.message.include?("Invalid route name, already in use")
       end
       registry.mark_route_applied(slug)

--- a/lib/vulnerabilities/registry.rb
+++ b/lib/vulnerabilities/registry.rb
@@ -66,7 +66,7 @@ module Vulnerabilities
       # (古いファイルが prepend_view_path で意図せず優先されるのを防ぐ)
       FileUtils.rm_f(Dir[Rails.root.join("lib/vulnerabilities/views/**/*.erb")])
 
-      @applied_routes&.clear
+      # @applied_routes&.clear  # routes.prepend は累積するため、リロードのたびにクリアしてはいけない
       resolve_conflicts!
       active_challenges.each do |klass|
         $stdout.puts "[Vuln] Applying challenge: #{klass.slug}"

--- a/test/integration/vulnerabilities/add_routes_idempotency_test.rb
+++ b/test/integration/vulnerabilities/add_routes_idempotency_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# routes.prepend に登録したブロックは Rails の clear! で再実行される。
+# また開発モードでは Registry クラスが再ロードされ、Singleton インスタンスが
+# リセットされることで apply_all! が複数回 add_routes を実行する。
+# いずれのケースでも ArgumentError が発生しないことを検証する。
+class AddRoutesIdempotencyTest < ActiveSupport::TestCase
+  TEST_SLUG = "test_add_routes_idempotency"
+  TEST_ROUTE_AS = :test_idempotency_route_unique
+
+  setup do
+    @registry = Vulnerabilities::Registry.instance
+    @original_active     = @registry.instance_variable_get(:@active).dup
+    @original_challenges = @registry.instance_variable_get(:@challenges).dup
+    @original_applied    = @registry.instance_variable_get(:@applied_routes)&.dup || Set.new
+    @original_prepend    = Rails.application.routes.instance_variable_get(:@prepend).dup
+
+    @registry.instance_variable_set(:@active, Set.new)
+    @registry.instance_variable_set(:@conflict_log, [])
+    @registry.instance_variable_set(:@applied_routes, Set.new)
+
+    dummy = Class.new(Vulnerabilities::Base) do
+      define_singleton_method(:slug) { "test_add_routes_idempotency" }
+      metadata { slot "route:test_add_routes_idempotency" }
+      def apply!
+        add_routes do
+          post "/test_idempotency_route_unique", to: "tasks#index", as: :test_idempotency_route_unique
+        end
+      end
+    end
+    @registry.instance_variable_get(:@challenges)[TEST_SLUG] = dummy
+    @registry.enable(TEST_SLUG)
+  end
+
+  teardown do
+    @registry.instance_variable_set(:@active, @original_active)
+    @registry.instance_variable_set(:@challenges, @original_challenges)
+    @registry.instance_variable_set(:@applied_routes, @original_applied)
+    @registry.instance_variable_set(:@conflict_log, [])
+    Rails.application.routes.instance_variable_set(:@prepend, @original_prepend)
+    Rails.application.reload_routes!
+  end
+
+  # apply_all! が2回実行され @prepend に同じブロックが2つ入った後、
+  # clear! が走っても ArgumentError が出ない。
+  # （開発モードで Registry Singleton がリセットされ apply_all! が再実行されるシナリオ）
+  test "clear! after double apply_all! does not raise ArgumentError" do
+    @registry.apply_all!
+    # Registry Singleton リセットをシミュレート: @applied_routes をクリアして再適用
+    @registry.instance_variable_set(:@applied_routes, Set.new)
+    @registry.apply_all!
+    # この時点で @prepend に同じブロックが2つ積まれている
+
+    assert_nothing_raised do
+      Rails.application.routes.clear!
+    end
+  end
+end


### PR DESCRIPTION
## 現象

`VULN_CHALLENGES=all`（または ssrf を含む組み合わせ）で起動し、ログイン後に `/tasks` へアクセスすると以下のエラーが発生してページが表示されない。

```
ArgumentError (Invalid route name, already in use: 'preview_url_task')
lib/vulnerabilities/challenges/ssrf.rb:88:in 'block in Vulnerabilities::Challenges::Ssrf#apply!'
```

## 原因

### 直接原因

`add_routes` は `routes.prepend(&block)` でブロックを Rails の `@prepend` リストに登録する。Rails が `clear!` を呼ぶと `@prepend` の全ブロックが再実行される。同じブロックが複数回 `@prepend` に積まれている場合、2つ目以降の実行でルート名重複の `ArgumentError` が発生する。

この `ArgumentError` は `routes.draw` を包む `rescue` の**外側**（`clear!` 内部）で起きるため捕捉されずアプリがクラッシュしていた。

### なぜ `@prepend` に同じブロックが複数回積まれるか

開発モードでは Rails が各リクエスト前に `to_prepare` コールバックを実行する。このとき `Vulnerabilities::Registry` クラスが再ロードされ Singleton インスタンスがリセットされるため、`@applied_routes` による重複ガードが効かなくなる。結果として `add_routes` → `routes.prepend` が毎リクエストごとに呼ばれ、ブロックが蓄積する。

### 前回修正 e19f3cd のギャップ

e19f3cd では `@applied_routes` トラッキングと `routes.draw` 周りの `rescue` を導入したが、`@prepend` ブロックの再実行パスは保護されていなかった。また `@applied_routes&.clear` を `apply_all!` 内に置いていたため、クリアのたびにブロックが再登録されていた（のちにコメントアウト済みだが未コミット）。

## 対応アプローチ

`routes.prepend` に渡すブロックを idempotent なラッパー (`idempotent` proc) で包む。`clear!` によって何度再実行されても、重複ルート名エラーをラッパー内で無視するため `ArgumentError` が外部に伝播しない。

```ruby
idempotent = proc {
  begin
    instance_exec(&block)
  rescue ArgumentError => e
    raise e unless e.message.include?("Invalid route name, already in use")
  end
}
routes.prepend(&idempotent)
```

`@applied_routes&.clear` のコメントアウトも同時にコミット（ブロック蓄積を防ぐため）。

## 検証

- **リグレッションテスト追加**: `double apply_all! + clear!` で `ArgumentError` が出ないことを単体テストで担保（RED → GREEN 確認済み）
- **全テストスイート**: 111 tests, 274 assertions, 0 failures, 0 errors
- **コンテナ起動確認**: エラー報告時と同じ 19 challenge 組み合わせで起動 → ログイン後 `/tasks` アクセスで `ArgumentError` が発生しないことを確認