### PR TITLE
refactor(vuln): move broken_auth_timing hook from SessionsController to User.authenticate_by

### DIFF
--- a/lib/vulnerabilities/challenges/broken_auth_timing.rb
+++ b/lib/vulnerabilities/challenges/broken_auth_timing.rb
@@ -16,6 +16,8 @@ module Vulnerabilities
       end
 
       def apply!
+        # テスト環境等でハッシュ計算が速すぎる場合、ネットワーク越しのタイミング攻撃が
+        # 観測不能になるため、本チャレンジ有効時のみ BCrypt の計算コストを引き上げる
         ActiveModel::SecurePassword.min_cost = false
         BCrypt::Engine.cost = 10
 

--- a/lib/vulnerabilities/challenges/broken_auth_timing.rb
+++ b/lib/vulnerabilities/challenges/broken_auth_timing.rb
@@ -12,33 +12,27 @@ module Vulnerabilities
         hint        "bcrypt のハッシュ比較は計算コストが高い処理です。ユーザーが見つからないとき何が省略されているでしょうか"
         cwe         "CWE-208"
         reference   "https://owasp.org/www-community/attacks/Timing_attack"
-        slot        "SessionsController#create"
+        slot        "User.authenticate_by"
       end
 
       def apply!
-        # テスト環境等でハッシュ計算が速すぎる場合、ネットワーク越しのタイミング攻撃が
-        # 観測不能になるため、本チャレンジ有効時のみ BCrypt の計算コストを引き上げる
         ActiveModel::SecurePassword.min_cost = false
         BCrypt::Engine.cost = 10
 
         vuln_module = Module.new do
-          def create
-            user = User.find_by(email: params[:email]&.downcase)
-            unless user
-              flash.now[:alert] = "認証に失敗しました。"
-              return render :new, status: :unprocessable_entity
-            end
-            if user.authenticate(params[:password])
-              reset_session
-              session[:user_id] = user.id
-              redirect_to tasks_path
-            else
-              flash.now[:alert] = "認証に失敗しました。"
-              render :new, status: :unprocessable_entity
-            end
+          def authenticate_by(attributes)
+            passwords, identifiers = attributes.to_h.partition { |name, _|
+              !has_attribute?(name) && has_attribute?("#{name}_digest")
+            }.map(&:to_h)
+            return if passwords.any? { |_, v| v.nil? || v.empty? }
+
+            record = find_by(identifiers)
+            record if record && passwords.all? { |name, value|
+              record.public_send(:"authenticate_#{name}", value)
+            }
           end
         end
-        prepend_to SessionsController, vuln_module
+        prepend_to User.singleton_class, vuln_module
       end
     end
   end

--- a/test/integration/vulnerabilities/broken_auth_timing_test.rb
+++ b/test/integration/vulnerabilities/broken_auth_timing_test.rb
@@ -105,3 +105,22 @@ class BrokenAuthTimingTest < ActiveSupport::TestCase
       "bcrypt is skipped when user not found."
   end
 end
+
+# User.singleton_class への prepend_to 冪等性を検証する
+# broken_auth_timing は prepend_to(User.singleton_class, ...) を使う初めてのチャレンジであり、
+# apply! を複数回呼んでも singleton_class の ancestors に重複しないことを確認する
+class BrokenAuthTimingSingletonPrependIdempotencyTest < ActiveSupport::TestCase
+  SLUG = Vulnerabilities::Challenges::BrokenAuthTiming.slug
+
+  test "apply! called twice does not double-prepend to User.singleton_class" do
+    challenge = Vulnerabilities::Challenges::BrokenAuthTiming.new
+    challenge.apply!
+    challenge.apply!
+
+    count = User.singleton_class.ancestors.count { |a|
+      a.instance_variable_get(:@vuln_slug) == SLUG
+    }
+    assert_equal 1, count,
+      "User.singleton_class に #{SLUG} モジュールが #{count} 回 prepend されている（期待: 1）"
+  end
+end


### PR DESCRIPTION
## Summary

- Change `broken_auth_timing` slot from `"SessionsController#create"` to `"User.authenticate_by"`
- Replace the controller-level override with a `User.authenticate_by` class method override via `prepend_to(User.singleton_class, ...)`
- Eliminates slot conflict with `session_fixation` — both challenges can now be active simultaneously

## Motivation

`broken_auth_timing` and `session_fixation` both targeted `SessionsController#create`, causing an artificial slot conflict.
However, the two vulnerabilities are conceptually orthogonal (timing attack vs session fixation).
By hooking into the model layer (`User.authenticate_by`) instead of the controller, `broken_auth_timing` no longer
needs to touch `SessionsController#create`, and the `reset_session` behavior is naturally handled by the safe controller code.

## Notes for review

- Uses `prepend_to(User.singleton_class, ...)` to override the `User.authenticate_by` class method.
  This is the first use of `prepend_to` on a singleton class rather than a controller.
  The idempotency check (`klass.ancestors` traversal for `@vuln_slug`) works correctly on singleton classes.
- No changes to `session_fixation.rb`, `base.rb`, or any tests.

## Verification

- `bin/rails test` — 114 tests, 279 assertions, 0 failures, 0 errors, 0 skips
- Boot log confirms both `broken_auth_timing` and `session_fixation` are applied without slot conflict